### PR TITLE
Render custom content from maintenance.md when supplied

### DIFF
--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    {{ 'PLUGIN_MAINTENANCE.OFFLINE_MARKDOWN'|t|markdown|raw }}
+    {{ page.content|default('PLUGIN_MAINTENANCE.OFFLINE_MARKDOWN'|t|markdown|raw) }}
 
     {% if maintenance.allow_login and not grav.user.authenticated %}
         <div id="maintenance-login" style="text-align: center;">


### PR DESCRIPTION
Allows site maintainers to set custom content in a custom `maintenance.md` file.

If custom content is not provided, defaults to translated `OFFLINE_MARKDOWN` value as per previous versions.